### PR TITLE
Deployment failed : threadsafe is a required field

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,6 +2,7 @@ application: helloworld
 version: 1
 runtime: php
 api_version: 1
+threadsafe: true
 
 handlers:
 - url: /.*


### PR DESCRIPTION
while using [Push-to-Deploy](https://cloud.google.com/tools/repo/push-to-deploy) Error message : "Deployment failed. Details: Deployment failed, details: { Failed to load application, threadsafe is a required field., none}"

i am using google git with "Build with and run tests :Deploy source only (Python, PHP)" no billing with netbean IDE to push my hello world code ([link to google tutorial](https://cloud.google.com/appengine/docs/php/gettingstarted/helloworld)) there but failed after adding threadsafe solved my problem
