### PR TITLE
Adding helpful tip to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ appengine-php-guestbook
 ================================
 
 Guestbook demo for Google App Engine that uses PHP
+
+Tip: See [this repo's branches](https://github.com/GoogleCloudPlatform/appengine-php-guestbook/branches) to view the code.


### PR DESCRIPTION
Folks who want to preview the repo before following the AppEngine tutorial will only see this readme on first glance. Adding a tip to view the branches to see the code.